### PR TITLE
Crashes encountered with msvc2017/Windows

### DIFF
--- a/activeregioncache.cpp
+++ b/activeregioncache.cpp
@@ -59,7 +59,9 @@ void ActiveRegionCache::coalesceCache(uint64_t cache_index) {
     uint64_t forward_index = 1;
     auto forward_iter = iter;
     ++forward_iter;
-    while (forward_iter->first == current_address + (forward_index * region_size)) {
+    while (forward_iter != cache.end() &&
+           forward_iter->first == current_address + (
+           forward_index * region_size)) {
       keys_to_remove.push_back(forward_iter->first);
       ++forward_iter;
       ++forward_index;

--- a/glheapdiagramlayer.cpp
+++ b/glheapdiagramlayer.cpp
@@ -34,8 +34,10 @@ void GLHeapDiagramLayer::refreshGLBuffer(bool bind) {
   if (layer_vertex_buffer_.size() < (layer_vertices_.size() * sizeof(HeapVertex))) {
     layer_vertex_buffer_.allocate(layer_vertices_.size() * sizeof(HeapVertex));
   }
-  layer_vertex_buffer_.write(0, &layer_vertices_[0],
-    layer_vertices_.size() * sizeof(HeapVertex));
+  if(layer_vertices_.size() > 0) {
+      layer_vertex_buffer_.write(0, &layer_vertices_[0],
+        layer_vertices_.size() * sizeof(HeapVertex));
+  }
   if (bind) {
     layer_vertex_buffer_.release();
   }


### PR DESCRIPTION
Hello,

While porting it to Windows I have encountered at least two issues:

- First one: the `forward_iter` iterator was moving forward a bit too much and was hitting the end of the cache :)
- Second one: the `layer_vertices` vector can be empty sometimes and in which case `&layer_vertices_[0]` is pointing out of bounds

I have other cosmetics / simple changes for Windows support so let me know if you are interested in those; in which case I'll be happy to work with you to upstream them.

Cheers