### PR TITLE
Move to use conanfile.py instead

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,17 @@
 cmake_minimum_required(VERSION 3.10)
 project(heap_history_viewer CXX)
 
+set(CMAKE_CPP_STANDARD 17)
+
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
-include(${CMAKE_SOURCE_DIR}/conan.cmake)
-
-if (DEFINED ENV{CMAKE_PREFIX_PATH})
-    message(STATUS "Getting Qt from the system. CMAKE_PREFIX_PATH = $ENV{CMAKE_PREFIX_PATH}")
-    set(NEEDED_CONAN_DEPENDENCIES gflags/2.2.2@bincrafters/stable)
-else ()
-    message(STATUS "To use the Qt from your system, set the CMAKE_PREFIX_PATH env var")
-    message(STATUS "Trying to get Qt from Conan")
-    message(STATUS "If it fails try: 'conan remote add bincrafters \"https://api.bintray.com/conan/bincrafters/public-conan\"'")
-    set(NEEDED_CONAN_DEPENDENCIES gflags/2.2.2@bincrafters/stable qt/5.12.6@bincrafters/stable)
-endif ()
-
-conan_cmake_run(REQUIRES ${NEEDED_CONAN_DEPENDENCIES} BASIC_SETUP BUILD missing)
-
-set(CMAKE_CPP_STANDARD 17)
+include(conan.cmake)
+conan_cmake_run(CONANFILE conanfile.py BASIC_SETUP CMAKE_TARGETS BUILD missing)
+if (NOT DEFINED ENV{CMAKE_PREFIX_PATH})
+    file(COPY ${CMAKE_BINARY_DIR}/qt.conf DESTINATION ${CMAKE_BINARY_DIR}/bin/)
+endif()
 
 find_package(Qt5 COMPONENTS Widgets REQUIRED)
 find_package(Qt5Test REQUIRED)
@@ -68,7 +60,7 @@ add_executable(HeapVizGL
         vertex.cpp)
 
 target_link_libraries(HeapVizGL
-        ${CONAN_LIBS}
+        CONAN_PKG::gflags
         OpenGL::GL
         Qt5::Widgets)
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,24 @@
+import os
+from conans import ConanFile, CMake
+
+class HeapHistoryViewer(ConanFile):
+
+    settings = "os", "compiler", "build_type", "arch"
+    platform_qt = os.getenv("CMAKE_PREFIX_PATH")
+    generators = "cmake", "qt" if not platform_qt else "cmake"
+
+    def requirements(self):
+        platform_qt = os.getenv("CMAKE_PREFIX_PATH")
+        if not platform_qt:
+            self.output.info("CMAKE_PREFIX_PATH not set")
+            self.output.info("To use the Qt from your system, set the CMAKE_PREFIX_PATH env var")
+            self.output.info("Trying to get Qt from Conan")
+            self.output.info("If it fails try: 'conan remote add bincrafters \"https://api.bintray.com/conan/bincrafters/public-conan\"'")
+            self.requires("qt/5.12.6@bincrafters/stable")
+        else:
+            self.output.info("Getting Qt from the system. CMAKE_PREFIX_PATH = " + platform_qt)
+        self.requires("gflags/2.2.2")
+
+    def imports(self):
+        self.copy("*.dll", dst="bin", src="bin")
+        self.copy("*.dylib*", dst="bin", src="lib")


### PR DESCRIPTION
This includes the copying of the Qt dlls and copying in of qt.conf when using conan - which means it runs out of the box on Windows.